### PR TITLE
Add documentation around how titlify is smarter titleize

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -12,27 +12,35 @@ The most thorough titlecasing function I found was Patrick Hogan's in his [steri
 Usage
 -----
 
-Titlify provides functionality both as class methods on the Titlify module and as extensions to the String class. 
+Titlify provides functionality both as class methods on the Titlify module and as extensions to the String class.
 
-    Titlify.titlify("make title") # => "Make Title"
+  ```ruby
+  Titlify.titlify("make title") # => "Make Title"
 
-    "make title".titlify # => "Make Title"
+  "make title".titlify # => "Make Title"
 
-    title = "make title"
-    title.titlify!
-    title # => "Make Title"
+  title = "make title"
+  title.titlify!
+  title # => "Make Title"
+  ```
 
 
 Titlecase
 ---------
 
-Format text appropriately for titles. This method is much smarter than ActiveSupport's titlecase. The algorithm is based on work done by John Gruber et al (http://daringfireball.net/2008/08/title_case_update). It gets closer to the AP standard for title capitalization, including proper support for small words and handles a variety of edge cases.
+Format text appropriately for titles. This method is much smarter than ActiveSupport's `titlecase`, which effectively calls `String#capitalize` on the first character of each word in a string without regard for style. The algorithm is based on work done by John Gruber et al (http://daringfireball.net/2008/08/title_case_update). It gets closer to the AP standard for title capitalization, including proper support for small words and handles a variety of edge cases.
 
+  ```ruby
 	"Q&A with Steve Jobs: 'That's what happens in technology'".titlify
 	# => "Q&A With Steve Jobs: 'That's What Happens in Technology'"
-	
+
 	"Small word at end is nothing to be afraid of".titlify
 	# => "Small Word at End Is Nothing to Be Afraid Of"
+
+	# Compare with ActiveSupport::Inflector.titlecase
+	"Small word at end is nothing to be afraid of".titlecase
+	# => "Small Word At End Is Nothing To Be Afraid Of"
+  ```
 
 
 Installation
@@ -41,7 +49,7 @@ Installation
 Install with RubyGems:
 
     gem install titlify
-    
+
 Status
 ------
 


### PR DESCRIPTION
This PR adds doc fixes. Firstly, it adds syntax highlighting to the two code blocks (which I think makes it easier to grok, and it looks a little nicer). But more importantly, it adds the `ActiveSupport::Inflector.titlecase` example to illustrate `titlify`'s superiority. You mention that it's better in the preceding paragraph, but I think an illustration makes it much clearer. (It also helped to dig into the Rails source and look at exactly what `titlecase` was doing, which, sure enough, was just calling `capitalize` on the first character of every string. I was surprised.)

It also pedantically removes a few whitespace errors.
