### PR TITLE
Fix bug in which titlify replaced the original string

### DIFF
--- a/lib/titlify/string_extensions.rb
+++ b/lib/titlify/string_extensions.rb
@@ -5,7 +5,7 @@ module Titlify
   module StringExtensions
     def self.included(base)
       Titlify.methods(false).each do |method|
-        eval("def #{method}(*args, &block); Titlify.#{method}(self, *args, &block); end")
+        eval("def #{method}(*args, &block); Titlify.#{method}(self.clone, *args, &block); end")
         eval("def #{method}!(*args, &block); replace Titlify.#{method}(self, *args, &block); end")
       end
     end

--- a/spec/titlify_spec.rb
+++ b/spec/titlify_spec.rb
@@ -1,9 +1,11 @@
 require 'spec_helper'
 
 describe Titlify do
-  it "titlecases a string object" do
-    title = "this is the title of the post".titlify
-    title.should eq("This Is the Title of the Post")
+  it "titlecases a string object not in place" do
+    title = "this is the title of the post"
+    new_title = title.titlify
+    title.should eq("this is the title of the post")
+    new_title.should eq("This Is the Title of the Post")
   end
 
   it "titlecases a string object in place" do


### PR DESCRIPTION
@joshhepworth I've added to the original test to demonstrate the bug.  I then added a .clone call which ensures the original is not modified when doing 

```
a = 'hello'
a.titlify
```